### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/Lab1/server/saas-sam-stack.yaml
+++ b/Lab1/server/saas-sam-stack.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: product-manager.get
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -24,7 +24,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: product-manager.put
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -42,7 +42,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: product-manager.delete
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -60,7 +60,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: order-manager.get
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -78,7 +78,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: order-manager.put
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -96,7 +96,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: order-manager.delete
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess

--- a/Lab1/server/sam-output.yaml
+++ b/Lab1/server/sam-output.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: product-manager.get
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies:
       - AmazonDynamoDBReadOnlyAccess
@@ -29,7 +29,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: product-manager.put
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies:
       - AmazonDynamoDBFullAccess
@@ -52,7 +52,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: product-manager.delete
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies:
       - AmazonDynamoDBFullAccess
@@ -75,7 +75,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: order-manager.get
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies:
       - AmazonDynamoDBReadOnlyAccess
@@ -98,7 +98,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: order-manager.put
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies:
       - AmazonDynamoDBFullAccess
@@ -121,7 +121,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: order-manager.delete
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies:
       - AmazonDynamoDBFullAccess

--- a/Lab2/server/saas-sam-stack.yaml
+++ b/Lab2/server/saas-sam-stack.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       Handler: product-manager.get
       #TODO: Add reference to Layers
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -27,7 +27,7 @@ Resources:
       Handler: product-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -46,7 +46,7 @@ Resources:
     Properties:
       Handler: product-manager.delete
       #TODO: Add reference to Layers
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -65,7 +65,7 @@ Resources:
     Properties:
       Handler: order-manager.get
       #TODO: Add reference to Layers
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -84,7 +84,7 @@ Resources:
     Properties:
       Handler: order-manager.put
       #TODO: Add reference to Layers
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -103,7 +103,7 @@ Resources:
     Properties:
       Handler: order-manager.delete
       #TODO: Add reference to Layers
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess

--- a/Lab3/server/saas-sam-stack.yaml
+++ b/Lab3/server/saas-sam-stack.yaml
@@ -8,7 +8,7 @@ Resources:
       Handler: product-manager.get
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -29,7 +29,7 @@ Resources:
       Handler: product-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -50,7 +50,7 @@ Resources:
       Handler: product-manager.delete
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -71,7 +71,7 @@ Resources:
       Handler: order-manager.get
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -92,7 +92,7 @@ Resources:
       Handler: order-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -113,7 +113,7 @@ Resources:
       Handler: order-manager.delete
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -136,6 +136,6 @@ Resources:
             ContentUri: layers/
             CompatibleRuntimes:
               - nodejs6.10
-              - nodejs8.10
+              - nodejs10.x
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain

--- a/Lab4/server/saas-sam-stack.yaml
+++ b/Lab4/server/saas-sam-stack.yaml
@@ -8,7 +8,7 @@ Resources:
       Handler: product-manager.get
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -29,7 +29,7 @@ Resources:
       Handler: product-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -50,7 +50,7 @@ Resources:
       Handler: product-manager.delete
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -71,7 +71,7 @@ Resources:
       Handler: order-manager.get
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -92,7 +92,7 @@ Resources:
       Handler: order-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -113,7 +113,7 @@ Resources:
       Handler: order-manager.delete
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -136,6 +136,6 @@ Resources:
             ContentUri: layers/
             CompatibleRuntimes:
               - nodejs6.10
-              - nodejs8.10
+              - nodejs10.x
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain

--- a/Solution/Lab1/server/saas-sam-stack.yaml
+++ b/Solution/Lab1/server/saas-sam-stack.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: product-manager.get
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -24,7 +24,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: product-manager.put
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -42,7 +42,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: product-manager.delete
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -60,7 +60,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: order-manager.get
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -78,7 +78,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: order-manager.put
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -96,7 +96,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: order-manager.delete
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess

--- a/Solution/Lab2/server/saas-sam-stack.yaml
+++ b/Solution/Lab2/server/saas-sam-stack.yaml
@@ -8,7 +8,7 @@ Resources:
       Handler: product-manager.get
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -28,7 +28,7 @@ Resources:
       Handler: product-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -48,7 +48,7 @@ Resources:
       Handler: product-manager.delete
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -68,7 +68,7 @@ Resources:
       Handler: order-manager.get
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -88,7 +88,7 @@ Resources:
       Handler: order-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -108,7 +108,7 @@ Resources:
       Handler: order-manager.delete
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -130,6 +130,6 @@ Resources:
             ContentUri: layers/
             CompatibleRuntimes:
               - nodejs6.10
-              - nodejs8.10
+              - nodejs10.x
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain

--- a/Solution/Lab3/server/saas-sam-stack.yaml
+++ b/Solution/Lab3/server/saas-sam-stack.yaml
@@ -8,7 +8,7 @@ Resources:
       Handler: product-manager.get
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -29,7 +29,7 @@ Resources:
       Handler: product-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -50,7 +50,7 @@ Resources:
       Handler: product-manager.delete
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -71,7 +71,7 @@ Resources:
       Handler: order-manager.get
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -92,7 +92,7 @@ Resources:
       Handler: order-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -113,7 +113,7 @@ Resources:
       Handler: order-manager.delete
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 5
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -136,6 +136,6 @@ Resources:
             ContentUri: layers/
             CompatibleRuntimes:
               - nodejs6.10
-              - nodejs8.10
+              - nodejs10.x
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain

--- a/Solution/Lab4/server/saas-sam-stack.yaml
+++ b/Solution/Lab4/server/saas-sam-stack.yaml
@@ -8,7 +8,7 @@ Resources:
       Handler: product-manager.get
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -29,7 +29,7 @@ Resources:
       Handler: product-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -50,7 +50,7 @@ Resources:
       Handler: product-manager.delete
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -71,7 +71,7 @@ Resources:
       Handler: order-manager.get
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBReadOnlyAccess
@@ -92,7 +92,7 @@ Resources:
       Handler: order-manager.put
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -113,7 +113,7 @@ Resources:
       Handler: order-manager.delete
       Layers: 
         - !Ref DependencyLayer
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 15
       Policies: 
         - AmazonDynamoDBFullAccess
@@ -136,6 +136,6 @@ Resources:
             ContentUri: layers/
             CompatibleRuntimes:
               - nodejs6.10
-              - nodejs8.10
+              - nodejs10.x
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain


### PR DESCRIPTION
CloudFormation templates in aws-serverless-saas-layers have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.