### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/Lab3/server/saas-sam-stack.yaml
+++ b/Lab3/server/saas-sam-stack.yaml
@@ -135,7 +135,7 @@ Resources:
             Description: Dependencies for centralized services
             ContentUri: layers/
             CompatibleRuntimes:
-              - nodejs6.10
+              - nodejs10.x
               - nodejs8.10
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain

--- a/Lab4/server/saas-sam-stack.yaml
+++ b/Lab4/server/saas-sam-stack.yaml
@@ -135,7 +135,7 @@ Resources:
             Description: Dependencies for centralized services
             ContentUri: layers/
             CompatibleRuntimes:
-              - nodejs6.10
+              - nodejs10.x
               - nodejs8.10
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain

--- a/Solution/Lab2/server/saas-sam-stack.yaml
+++ b/Solution/Lab2/server/saas-sam-stack.yaml
@@ -129,7 +129,7 @@ Resources:
             Description: Dependencies for centralized services
             ContentUri: layers/
             CompatibleRuntimes:
-              - nodejs6.10
+              - nodejs10.x
               - nodejs8.10
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain

--- a/Solution/Lab3/server/saas-sam-stack.yaml
+++ b/Solution/Lab3/server/saas-sam-stack.yaml
@@ -135,7 +135,7 @@ Resources:
             Description: Dependencies for centralized services
             ContentUri: layers/
             CompatibleRuntimes:
-              - nodejs6.10
+              - nodejs10.x
               - nodejs8.10
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain

--- a/Solution/Lab4/server/saas-sam-stack.yaml
+++ b/Solution/Lab4/server/saas-sam-stack.yaml
@@ -135,7 +135,7 @@ Resources:
             Description: Dependencies for centralized services
             ContentUri: layers/
             CompatibleRuntimes:
-              - nodejs6.10
+              - nodejs10.x
               - nodejs8.10
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain


### PR DESCRIPTION
CloudFormation templates in aws-serverless-saas-layers have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.